### PR TITLE
Handle paginated API data across sales views

### DIFF
--- a/frontend/src/ui/pages/ExpeditionPage.vue
+++ b/frontend/src/ui/pages/ExpeditionPage.vue
@@ -487,7 +487,8 @@ watch(courierModalOpen, (open) => {
 
 async function loadCouriers() {
   try {
-    couriers.value = await listCouriers();
+    const response = await listCouriers({ page: 1, pageSize: 500 });
+    couriers.value = response.items;
   } catch (error) {
     console.error(error);
     toast.push('Gagal memuat daftar ekspedisi.', 'error');

--- a/frontend/src/ui/pages/OrderPage.vue
+++ b/frontend/src/ui/pages/OrderPage.vue
@@ -299,7 +299,7 @@
         <footer class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div class="text-sm text-slate-600 flex items-center gap-2">
             <BanknotesIcon class="h-5 w-5 text-emerald-600" />
-            <span>Total bayar Rp {{ formatCurrency(orderTotal) }} · Profit Rp {{ formatCurrency(estimatedProfit) }}</span>
+            <span>Total bayar Rp {{ formatCurrency(orderPaymentTotal) }} · Profit Rp {{ formatCurrency(estimatedProfit) }}</span>
           </div>
           <button type="submit" class="btn-primary" :disabled="!canSubmit || savingOrder">
             <PrinterIcon class="h-5 w-5" />
@@ -386,7 +386,13 @@
           Produk terlaris: {{ orderInsights.topProduct }}
         </div>
       </div>
-      <div v-if="!orders.length" class="text-sm text-slate-500">Belum ada order.</div>
+      <div
+        v-if="ordersError"
+        class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600"
+      >
+        {{ ordersError }}
+      </div>
+      <div v-else-if="!orders.length" class="text-sm text-slate-500">Belum ada order.</div>
       <div v-else-if="orderTotal === 0" class="text-sm text-slate-500">Tidak ada order yang cocok dengan pencarian.</div>
       <template v-else>
         <div v-for="order in orders" :key="order.id" class="border-t border-slate-200 p-4 space-y-3 first:border-t-0">
@@ -583,6 +589,7 @@ const customers = ref<Customer[]>([]);
 const products = ref<Product[]>([]);
 const orders = ref<Order[]>([]);
 const ordersLoading = ref(false);
+const ordersError = ref('');
 const orderTotal = ref(0);
 const orderSummaryMeta = ref<OrderListSummary | null>(null);
 const orderAvailableCouriers = ref<string[]>([]);
@@ -776,7 +783,7 @@ const totalCost = computed(() =>
   }, 0)
 );
 
-const orderTotal = computed(() => subtotal.value - form.discount + form.shippingCost);
+const orderPaymentTotal = computed(() => subtotal.value - form.discount + form.shippingCost);
 
 const estimatedProfit = computed(() => {
   const shippingCostToSubtract = isBuyerPayingShipping.value ? 0 : form.shippingCost;
@@ -1202,6 +1209,7 @@ async function loadOrders() {
     orderTotal.value = response.total;
     orderSummaryMeta.value = response.summary;
     orderAvailableCouriers.value = response.couriers;
+    ordersError.value = '';
   } catch (error) {
     console.error(error);
     if (requestId === orderFetchId) {
@@ -1209,6 +1217,8 @@ async function loadOrders() {
       orderTotal.value = 0;
       orderSummaryMeta.value = null;
       orderAvailableCouriers.value = [];
+      ordersError.value =
+        error instanceof Error && error.message ? error.message : 'Gagal memuat histori order.';
       toast.push('Gagal memuat histori order.', 'error');
     }
   } finally {

--- a/frontend/src/ui/pages/StockOpnamePage.vue
+++ b/frontend/src/ui/pages/StockOpnamePage.vue
@@ -561,8 +561,8 @@ function openOpnameDetail(opname: StockOpname) {
 
 async function loadProducts() {
   try {
-    const fetched = await listProducts();
-    products.value = fetched;
+    const fetched = await listProducts({ page: 1, pageSize: 500 });
+    products.value = fetched.items;
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
## Summary
- update the analytics dashboard to consume paginated customer, product, and order responses while preserving aggregate metrics
- adjust stock opname and expedition management pages to read items from the new paginated list endpoints
- surface order history load failures in the order page with a tracked error state tied to the paginated fetch

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd761028288325b8b7e568fe4067db